### PR TITLE
Change methods visibility for class extensions

### DIFF
--- a/src/EnvatoApi.php
+++ b/src/EnvatoApi.php
@@ -18,7 +18,7 @@ class EnvatoApi{
 	}
 
 
-	private function GET($endpoint, $query = []){
+	protected function GET($endpoint, $query = []){
 		try {
 			$response = $this->client->request('GET', $endpoint,[
 				'query' => $query,
@@ -37,7 +37,7 @@ class EnvatoApi{
 		}
 	}
 
-	private function checkResponse($response) {
+	protected function checkResponse($response) {
 		$success = [200, 201];
 		$statusCode = $response->getStatusCode();
 		if(in_array($statusCode, $success)) {


### PR DESCRIPTION
When methods are declared as private, other classes cannot access them when extending. Changing to protected, will allow classes to re-use that code.